### PR TITLE
feat: add project_name support with dynamic grouping

### DIFF
--- a/agent_json_schema.json
+++ b/agent_json_schema.json
@@ -74,6 +74,9 @@
         "network_name": {
             "type": "string"
         },
+        "project_name": {
+            "type": "string"
+        },
         "os": {
             "type": "object",
             "properties": {
@@ -124,6 +127,6 @@
             }
         }
     },
-    "required": ["client_name", "client_sw_version", "hardware", "hostname", "json_version", "local_time", "net_interfaces", "network_name", "os", "users"],
+    "required": ["client_name", "client_sw_version", "hardware", "hostname", "json_version", "local_time", "net_interfaces", "network_name", "project_name", "os", "users"],
     "additionalProperties": false
 }

--- a/nyarlathotep-agent/agent.py
+++ b/nyarlathotep-agent/agent.py
@@ -11,7 +11,7 @@ def main():
     print("Starting agent ...")
     print("Software version: " + CLIENT_SW_VERSION)
     config = ConfigFile()
-    data = DataPusher(CLIENT_SW_VERSION, config.custom_name, config.remote_server_url)
+    data = DataPusher(CLIENT_SW_VERSION, config.custom_name, config.remote_server_url, config.project_name)
 
     while True:
         start_time = time.time()

--- a/nyarlathotep-agent/config_file.py
+++ b/nyarlathotep-agent/config_file.py
@@ -9,6 +9,7 @@ CONFIG_FILE = 'config.ini'
 DEFAULT_CUSTOM_NAME = "WORKSTATION"
 DEFAULT_UPDATE_INTERVAL = 30  # in seconds
 DEFAULT_REMOTE_SERVER_URL = "http://localhost:8080/client_update"
+DEFAULT_PROJECT_NAME = "PROJECT_1"
 
 class ConfigFile:
     """ConfigFile class to read and write the configuration file for the client."""	
@@ -20,7 +21,8 @@ class ConfigFile:
             config['SETTINGS'] = {
                 'CUSTOM_NAME': DEFAULT_CUSTOM_NAME,
                 'UPDATE_INTERVAL': str(DEFAULT_UPDATE_INTERVAL),
-                'REMOTE_SERVER_URL': DEFAULT_REMOTE_SERVER_URL
+                'REMOTE_SERVER_URL': DEFAULT_REMOTE_SERVER_URL,
+                'PROJECT_NAME': DEFAULT_PROJECT_NAME
             }
             with open(CONFIG_FILE, 'w', encoding='utf-8') as configfile:
                 config.write(configfile)
@@ -42,6 +44,10 @@ class ConfigFile:
             config.set('SETTINGS', 'REMOTE_SERVER_URL', DEFAULT_REMOTE_SERVER_URL)
             updated = True
 
+        if not config.has_option('SETTINGS', 'PROJECT_NAME'):
+            config.set('SETTINGS', 'PROJECT_NAME', DEFAULT_PROJECT_NAME)
+            updated = True
+
         if updated:
             with open(CONFIG_FILE, 'w', encoding='utf-8') as configfile:
                 config.write(configfile)
@@ -50,7 +56,9 @@ class ConfigFile:
         self.custom_name = config.get('SETTINGS', 'CUSTOM_NAME')
         self.update_interval = config.getint('SETTINGS', 'UPDATE_INTERVAL')
         self.remote_server_url = config.get('SETTINGS', 'REMOTE_SERVER_URL')
+        self.project_name = config.get('SETTINGS', 'PROJECT_NAME')
 
         print(f"Custom Name: {self.custom_name}")
         print(f"Update Interval: {self.update_interval}")
         print(f"Remote Server URL: {self.remote_server_url}")
+        print(f"Project Name: {self.project_name}")

--- a/nyarlathotep-agent/data_pusher.py
+++ b/nyarlathotep-agent/data_pusher.py
@@ -9,11 +9,12 @@ from versions import JSON_VERSION
 class DataPusher:
     """DataPusher class is responsible for sending the data to the remote server."""
 
-    def __init__(self, client_sw_version, client_name, remote_server_url) -> None:
+    def __init__(self, client_sw_version, client_name, remote_server_url, project_name) -> None:
         self.client_sw_version = client_sw_version
         self.json_version = JSON_VERSION
         self.client_name = client_name
         self.remote_server_url = remote_server_url
+        self.project_name = project_name
         self.collected_data = {}
         self.last_json = None
 
@@ -26,6 +27,7 @@ class DataPusher:
             "client_sw_version": self.client_sw_version,
             "local_time": time.strftime('%Y-%m-%d %H:%M:%S', time.localtime()),
             "json_version": self.json_version,
+            "project_name": self.project_name,
             "hostname": data.hostname,
             "network_name": data.network_name,
             "net_interfaces": data.net_interfaces,

--- a/nyarlathotep-backend/server.py
+++ b/nyarlathotep-backend/server.py
@@ -65,7 +65,7 @@ def client_update():
 
 @app.route('/workstations_status', methods=['GET'])
 def status_data():
-    """ Serve all the data from the clients as an array of JSON objects without customName. """	
+    """ Serve all the data from the clients as an array of JSON objects with metadata. """	
 
     current_time = datetime.now(timezone.utc).timestamp()
 
@@ -77,8 +77,12 @@ def status_data():
     # Creates an array of clients' data
     data_list = [details for details in client_data_map.values()]
 
-    # returns the array as JSON
-    response = make_response(jsonify(data_list), 200)
+    # Returns workstations data
+    response_data = {
+        "workstations": data_list
+    }
+
+    response = make_response(jsonify(response_data), 200)
     response.headers['Content-Type'] = 'application/json; charset=utf-8'
     return response
 

--- a/nyarlathotep-backend/test/client_JSON_example.json
+++ b/nyarlathotep-backend/test/client_JSON_example.json
@@ -11,6 +11,7 @@
   "hostname": "TD0262245",
   "json_version": "2.0",
   "local_time": "2024-09-06 21:41:24",
+  "project_name": "PROJECT_1",
   "net_interfaces": [
     {
       "interface": "Ethernet 8",

--- a/nyarlathotep-frontend/src/routes/+layout.svelte
+++ b/nyarlathotep-frontend/src/routes/+layout.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
+    import { onMount } from 'svelte';
     import "bootstrap/dist/css/bootstrap.min.css";
     import "bootstrap-icons/font/bootstrap-icons.min.css";
+    
+    // Import Bootstrap JS only on client side
+    onMount(async () => {
+        await import("bootstrap/dist/js/bootstrap.bundle.min.js");
+    });
 </script>
 
 <slot />

--- a/nyarlathotep-frontend/src/routes/+page.svelte
+++ b/nyarlathotep-frontend/src/routes/+page.svelte
@@ -12,16 +12,61 @@
   const refreshInterval = 5 * 1000; // Refresh time of the page in milliseconds
 
   let resetProgressBar: boolean = false;
-
   let workstations: WorkstationStatus[] = [];
+  let expandedProjects: Record<string, boolean> = {};
+
+  // Group workstations by project_name
+  $: workstationsByProject = (() => {
+    const grouped: Record<string, WorkstationStatus[]> = {};
+    
+    // Group workstations by project_name (any project_name is valid)
+    workstations.forEach(workstation => {
+      const projectName = workstation.details.project_name || "Unassigned";
+      if (!grouped[projectName]) {
+        grouped[projectName] = [];
+      }
+      grouped[projectName].push(workstation);
+    });
+    
+    return grouped;
+  })();
+
+  // Get all project names that have workstations (sorted)
+  $: projectsWithWorkstations = Object.keys(workstationsByProject).sort();
+
+  // Initialize expanded state for new projects (default: first project expanded)
+  $: {
+    if (projectsWithWorkstations.length > 0 && Object.keys(expandedProjects).length === 0) {
+      expandedProjects[projectsWithWorkstations[0]] = true;
+    }
+    // Ensure all current projects have an expanded state
+    projectsWithWorkstations.forEach(projectName => {
+      if (!(projectName in expandedProjects)) {
+        expandedProjects[projectName] = false;
+      }
+    });
+  }
+
+  function toggleProject(projectName: string) {
+    expandedProjects[projectName] = !expandedProjects[projectName];
+    expandedProjects = { ...expandedProjects }; // Trigger reactivity
+  }
 
   async function fetchWorkstations() {
     try {
       const response = await fetch('/workstations_status');
       const data = await response.json();
 
-      // This allows svelte to re-render the component
-      workstations = [...data]; 
+      // Extract workstations from the response
+      // Support both new format (object with workstations) and old format (array)
+      if (data.workstations) {
+        workstations = [...data.workstations];
+      } else if (Array.isArray(data)) {
+        // Fallback for backward compatibility (if response is just an array)
+        workstations = [...data];
+      } else {
+        workstations = [];
+      }
 
       // Resets the progress bar
       resetProgressBar = true;
@@ -42,15 +87,67 @@
 <main>
   <HeaderBar version="2.2.0"/>
   <div class="container mt-4">
-    <div class="row">
-      {#each workstations as workstation}
-        <div class="col-sm-12 col-md-6 col-lg-4 col-xl-3 mb-4">
-          <WorkstationCard workstation_data={workstation} />
+    {#each projectsWithWorkstations as projectName}
+      {@const projectWorkstations = workstationsByProject[projectName]}
+      {@const collapseId = `collapse-${projectName}`}
+      {@const isExpanded = expandedProjects[projectName] || false}
+      
+      <div class="card mb-3 project-group-card">
+        <div class="card-header project-header" on:click={() => toggleProject(projectName)} role="button" tabindex="0" on:keydown={(e) => e.key === 'Enter' && toggleProject(projectName)}>
+          <div class="d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">
+              {projectName} 
+              <span class="badge bg-secondary ms-2">{projectWorkstations.length} {projectWorkstations.length === 1 ? 'workstation' : 'workstations'}</span>
+            </h5>
+            <i class="bi {isExpanded ? 'bi-chevron-up' : 'bi-chevron-down'}"></i>
+          </div>
         </div>
-      {/each}
-    </div>
+        <div 
+          class="collapse {isExpanded ? 'show' : ''}" 
+          id="{collapseId}">
+          <div class="card-body">
+            <div class="row">
+              {#each projectWorkstations as workstation}
+                <div class="col-sm-12 col-md-6 col-lg-4 col-xl-3 mb-4">
+                  <WorkstationCard workstation_data={workstation} />
+                </div>
+              {/each}
+            </div>
+          </div>
+        </div>
+      </div>
+    {/each}
+    
+    {#if projectsWithWorkstations.length === 0}
+      <div class="alert alert-info mt-4" role="alert">
+        No workstations available at the moment.
+      </div>
+    {/if}
   </div>
   <!--
   <BottomBar totalTime={refreshInterval} resetProgressBar={resetProgressBar}/>
   -->
 </main>
+
+<style>
+  .project-group-card {
+    border: 1px solid #dee2e6;
+    border-radius: 0.375rem;
+  }
+
+  .project-header {
+    background-color: #f8f9fa;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color 0.2s ease;
+  }
+
+  .project-header:hover {
+    background-color: #e9ecef;
+  }
+
+  .project-header:focus {
+    outline: 2px solid var(--primary-color, #0d6efd);
+    outline-offset: -2px;
+  }
+</style>

--- a/nyarlathotep-frontend/src/types.d.ts
+++ b/nyarlathotep-frontend/src/types.d.ts
@@ -40,6 +40,7 @@ export interface WorkstationDetails {
   network_name: string;
   os: OS;
   users: User[];
+  project_name: string;
 }
 
 export interface WorkstationStatus {

--- a/nyarlathotep-frontend/vite.config.ts
+++ b/nyarlathotep-frontend/vite.config.ts
@@ -36,6 +36,11 @@ export default defineConfig({
         target: backendUrl + '/workstations_status',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/workstations_status/, '')
+      },
+      '/client_update': {
+        target: backendUrl + '/client_update',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/client_update/, '')
       }
     }
   }


### PR DESCRIPTION
- Add PROJECT_NAME field to agent configuration (with no validation at all)
- Backend dynamically collects project names from workstations
- Frontend groups workstations by project with grouped cards (collapsible)
- Updated frontend